### PR TITLE
Add rel="sponsored noopener" to all affiliate links

### DIFF
--- a/blocks/bonus/bonus.php
+++ b/blocks/bonus/bonus.php
@@ -43,7 +43,7 @@
     </div>
 
     <div class="bonus-long__cta">
-      <a class="button button__primary" rel="nofollow" href="<?php echo $outputLink; ?>" target="_blank">Get</a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo $outputLink; ?>" target="_blank">Get</a>
     </div>
   </div>
 

--- a/blocks/casino-card/casino-card.php
+++ b/blocks/casino-card/casino-card.php
@@ -47,7 +47,7 @@ elseif ($options === "Description") $btn_output = "Play";
 
     <?php if ($link) : ?>
       <div class="casino-card__cta">
-        <a class="button button__primary" rel="nofollow" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank"><?php echo esc_html($btn_output); ?></a>
+        <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank"><?php echo esc_html($btn_output); ?></a>
       </div>
     <?php endif; ?>
 

--- a/blocks/casino-cta/casino-cta.php
+++ b/blocks/casino-cta/casino-cta.php
@@ -9,7 +9,7 @@ $link          = is_array($details_group) && !empty($details_group['affiliate_li
 // $closed         = is_array($details_group) && !empty($details_group['closed']) ? $details_group['closed'] : null;
 
 if ($link !== null): ?>
-  <a class="button button__primary mt-3" rel="nofollow" href="<?php echo esc_url($link); ?>" target="_blank">
+  <a class="button button__primary mt-3" rel="sponsored noopener" href="<?php echo esc_url($link); ?>" target="_blank">
     <?php echo esc_html($text ? $text : "Play"); ?>
   </a>
 <?php endif; ?>

--- a/blocks/casino-list/casino-list.php
+++ b/blocks/casino-list/casino-list.php
@@ -21,7 +21,7 @@ $casino_list = get_field('casino_list') ?? [];
     ?>
       <li>
         <?php echo esc_html($text); ?> - 
-        <a target="_blank" rel="nofollow" href="<?php echo esc_url($link); ?>">
+        <a target="_blank" rel="sponsored noopener" href="<?php echo esc_url($link); ?>">
           <?php echo esc_html($name); ?> 
           <?php echo get_svg_icon('external-link'); ?>
         </a>

--- a/blocks/details/details.php
+++ b/blocks/details/details.php
@@ -62,7 +62,7 @@ $permalink  = get_permalink($site_id);
   <div class="details-card__ctas">
     <a class="button button__outline" href="<?php echo esc_url($permalink); ?>">Review</a>   
     <?php if ($link) : ?>
-      <a class="button button__primary" rel="nofollow" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank">Play</a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank">Play</a>
     <?php endif; ?>    
   </div>
 

--- a/blocks/more/more.php
+++ b/blocks/more/more.php
@@ -13,7 +13,7 @@
 ?>
   <p>Want to learn more about <?php echo $name; ?>? <strong>Read our <a href="<?php echo $permalink ?>"><?php echo $name; ?> review</a></strong>.</p>
   <div class="mt-3">
-    <a href="<?php echo $link; ?>" rel="nofollow" target="_blank" class="button button__primary">Visit <?php echo $name; ?></a>
+    <a href="<?php echo $link; ?>" rel="sponsored noopener" target="_blank" class="button button__primary">Visit <?php echo $name; ?></a>
   </div>
 <?php endif; ?>
 

--- a/blocks/review-bonus/review-bonus.php
+++ b/blocks/review-bonus/review-bonus.php
@@ -11,13 +11,13 @@ $review_bonus_type = get_field('review_bonus_type');
 foreach ($review_bonus as $review_id) {
 
   $link_aff = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-  $link_output = '<a target="_blank" href="' . $link_aff . '" class="button button__primary"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
+  $link_output = '<a target="_blank" rel="sponsored noopener" href="' . $link_aff . '" class="button button__primary"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
 
   $logo = get_the_post_thumbnail_url($review_id, 'site-small-logo'); 
   $transparent_logo =  get_field('media_group', $review_id)['transparent_logo'] ?? null;
   
   $title = get_the_title($review_id);
-  $img_output = '<a class="img-link" href="' . $link_aff . '" target="_blank"><img width="100" height="auto" class="logo" src="' . $transparent_logo . '" alt="' . $title . '" title="' . $title . '"></a>';
+  $img_output = '<a class="img-link" href="' . $link_aff . '" target="_blank" rel="sponsored noopener"><img width="100" height="auto" class="logo" src="' . $transparent_logo . '" alt="' . $title . '" title="' . $title . '"></a>';
 
   $bonus_is_same = get_field('bonus_group', $review_id)['bonus_same'] ?? null;
    

--- a/blocks/review-cta/review-cta.php
+++ b/blocks/review-cta/review-cta.php
@@ -18,7 +18,7 @@ if ($goto_link !== null): ?>
   <div class="review-cta">
     <div class="review-cta__ctas">
       <a class="button button__outline" href="<?php echo get_the_permalink($id); ?>"><?php echo $name; ?> review</a>
-      <a class="button button__primary" rel="nofollow" href="<?php echo esc_url($goto_link); ?>" target="_blank">Goto <?php echo $name; ?></a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($goto_link); ?>" target="_blank">Goto <?php echo $name; ?></a>
     </div>
   </div>
 <?php endif; ?>

--- a/blocks/review-table/review-table.php
+++ b/blocks/review-table/review-table.php
@@ -96,7 +96,7 @@ $columns = [
     'icon' => '',
     'render' => function($review_id) {
       $link = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-      return $link ? '<a target="_blank" href="' . $link . '" class="button button__primary">Visit</a>' : '';
+      return $link ? '<a target="_blank" rel="sponsored noopener" href="' . $link . '" class="button button__primary">Visit</a>' : '';
     }
   ],
   'blockchain' => [

--- a/single-bonus.php
+++ b/single-bonus.php
@@ -199,7 +199,7 @@
                     </span>
                   </div>
                 <?php }; ?>
-                <a href="<?php echo $output_link; ?>" class="button button__primary" rel="nofollow" target="_blank">Get Bonus</a>
+                <a href="<?php echo $output_link; ?>" class="button button__primary" rel="sponsored noopener" target="_blank">Get Bonus</a>
               </div>
               <?php endif; ?>
               

--- a/single-review.php
+++ b/single-review.php
@@ -203,7 +203,7 @@ foreach ($faqs as $faq) {
           <?php if ($bonus) { ?>
             <p><?php echo get_svg_icon('present'); ?><?php echo $bonus; ?></p>
           <?php } ?>
-          <a href="<?php echo $link; ?>" class="button button__primary" target="_blank">Sign Up</a>
+          <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener">Sign Up</a>
         </div>
       <?php }; ?>
       

--- a/single-streamer.php
+++ b/single-streamer.php
@@ -107,7 +107,7 @@
                 <div class="bonus"><?php echo $siteBonus; ?></div>
               </div>
               <div class="site-card__buttons">
-                <a class="button button__primary" href="<?php echo $siteLink; ?>">Play</a>
+                <a class="button button__primary" href="<?php echo $siteLink; ?>" target="_blank" rel="sponsored noopener">Play</a>
                 <a class="" href="<?php echo $siteReviewLink; ?>">Read Review</a>
               </div>
             </div>

--- a/template-parts/card/bonus-pill.php
+++ b/template-parts/card/bonus-pill.php
@@ -39,7 +39,7 @@
     </div>
 
     <div class="card-absolute__ctas bonus-pill__cta">
-      <a class="button button__primary" href="<?php echo $bonusLink; ?>" target="_blank" rel="nofollow" aria-label="Visit <?php echo $name; ?>">
+      <a class="button button__primary" href="<?php echo $bonusLink; ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
        <?php echo get_svg_icon('external-link'); ?>
       </a>
     </div>

--- a/template-parts/card/card-hangzhou.php
+++ b/template-parts/card/card-hangzhou.php
@@ -71,7 +71,7 @@
         </a>
       <?php }; ?>
 
-      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank">Get Bonus</a>
+      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener">Get Bonus</a>
 
     </div>
   </div>

--- a/template-parts/card/card-hong-kong.php
+++ b/template-parts/card/card-hong-kong.php
@@ -52,7 +52,7 @@
   <?php if (!empty($link)) {  ?>
     <div class="card-absolute__ctas hong-kong-card__ctas">
       <a href="<?php echo the_permalink(); ?>" class="button button__outline" aria-label="Read <?php echo $name; ?> review">Review</a>
-      <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" aria-label="Goto <?php echo $name; ?>">Play</a>
+      <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Goto <?php echo $name; ?>">Play</a>
     </div>
   <?php }; ?>
 </div>

--- a/template-parts/card/card-shanghai.php
+++ b/template-parts/card/card-shanghai.php
@@ -73,7 +73,7 @@
         </a>
       <?php }; ?>
 
-      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" aria-label="Claim bonus at <?php echo $name; ?>">Get Bonus</a>
+      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo $name; ?>">Get Bonus</a>
 
     </div>
   </div>

--- a/template-parts/card/review-pill.php
+++ b/template-parts/card/review-pill.php
@@ -18,7 +18,7 @@
     </h3>
   </div>
   <div class="card-absolute__ctas review-pill__cta">
-    <a class="button button__primary" href="<?php echo $aff_link; ?>" target="_blank" rel="nofollow" aria-label="Visit <?php echo $name; ?>">
+    <a class="button button__primary" href="<?php echo $aff_link; ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
        <?php echo get_svg_icon('external-link'); ?>
     </a>
   </div>


### PR DESCRIPTION
Replaces rel="nofollow" and adds missing rel attributes across all affiliate link CTAs to comply with Google's sponsored link guidelines.