### PR TITLE
Add descriptive aria-labels to all affiliate link buttons

### DIFF
--- a/blocks/bonus/bonus.php
+++ b/blocks/bonus/bonus.php
@@ -43,7 +43,7 @@
     </div>
 
     <div class="bonus-long__cta">
-      <a class="button button__primary" rel="sponsored noopener" href="<?php echo $outputLink; ?>" target="_blank">Get</a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo $outputLink; ?>" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get</a>
     </div>
   </div>
 

--- a/blocks/casino-card/casino-card.php
+++ b/blocks/casino-card/casino-card.php
@@ -47,7 +47,7 @@ elseif ($options === "Description") $btn_output = "Play";
 
     <?php if ($link) : ?>
       <div class="casino-card__cta">
-        <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank"><?php echo esc_html($btn_output); ?></a>
+        <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank" aria-label="Visit <?php echo esc_attr($name); ?>"><?php echo esc_html($btn_output); ?></a>
       </div>
     <?php endif; ?>
 

--- a/blocks/casino-cta/casino-cta.php
+++ b/blocks/casino-cta/casino-cta.php
@@ -6,10 +6,11 @@ $text = get_field('text');
 // Review fields
 $details_group = $id ? get_field('details_group', $id) : null;
 $link          = is_array($details_group) && !empty($details_group['affiliate_link']) ? $details_group['affiliate_link'] : null;
+$name          = is_array($details_group) ? ($details_group['name'] ?? '') : '';
 // $closed         = is_array($details_group) && !empty($details_group['closed']) ? $details_group['closed'] : null;
 
 if ($link !== null): ?>
-  <a class="button button__primary mt-3" rel="sponsored noopener" href="<?php echo esc_url($link); ?>" target="_blank">
+  <a class="button button__primary mt-3" rel="sponsored noopener" href="<?php echo esc_url($link); ?>" target="_blank" aria-label="<?php echo esc_attr(($text ?: 'Play') . ($name ? ' at ' . $name : '')); ?>">
     <?php echo esc_html($text ? $text : "Play"); ?>
   </a>
 <?php endif; ?>

--- a/blocks/details/details.php
+++ b/blocks/details/details.php
@@ -62,7 +62,7 @@ $permalink  = get_permalink($site_id);
   <div class="details-card__ctas">
     <a class="button button__outline" href="<?php echo esc_url($permalink); ?>">Review</a>   
     <?php if ($link) : ?>
-      <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank">Play</a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($unique_link ?: $link); ?>" target="_blank" aria-label="Play at <?php echo esc_attr($name); ?>">Play</a>
     <?php endif; ?>    
   </div>
 

--- a/blocks/review-bonus/review-bonus.php
+++ b/blocks/review-bonus/review-bonus.php
@@ -11,7 +11,7 @@ $review_bonus_type = get_field('review_bonus_type');
 foreach ($review_bonus as $review_id) {
 
   $link_aff = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-  $link_output = '<a target="_blank" rel="sponsored noopener" href="' . $link_aff . '" class="button button__primary"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
+  $link_output = '<a target="_blank" rel="sponsored noopener" href="' . $link_aff . '" class="button button__primary" aria-label="Visit ' . esc_attr($title) . '"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
 
   $logo = get_the_post_thumbnail_url($review_id, 'site-small-logo'); 
   $transparent_logo =  get_field('media_group', $review_id)['transparent_logo'] ?? null;

--- a/blocks/review-table/review-table.php
+++ b/blocks/review-table/review-table.php
@@ -96,7 +96,7 @@ $columns = [
     'icon' => '',
     'render' => function($review_id) {
       $link = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-      return $link ? '<a target="_blank" rel="sponsored noopener" href="' . $link . '" class="button button__primary">Visit</a>' : '';
+      return $link ? '<a target="_blank" rel="sponsored noopener" href="' . $link . '" class="button button__primary" aria-label="Visit ' . esc_attr(get_the_title($review_id)) . '">Visit</a>' : '';
     }
   ],
   'blockchain' => [

--- a/single-bonus.php
+++ b/single-bonus.php
@@ -199,7 +199,7 @@
                     </span>
                   </div>
                 <?php }; ?>
-                <a href="<?php echo $output_link; ?>" class="button button__primary" rel="sponsored noopener" target="_blank">Get Bonus</a>
+                <a href="<?php echo $output_link; ?>" class="button button__primary" rel="sponsored noopener" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get Bonus</a>
               </div>
               <?php endif; ?>
               

--- a/single-review.php
+++ b/single-review.php
@@ -203,7 +203,7 @@ foreach ($faqs as $faq) {
           <?php if ($bonus) { ?>
             <p><?php echo get_svg_icon('present'); ?><?php echo $bonus; ?></p>
           <?php } ?>
-          <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener">Sign Up</a>
+          <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Sign up at <?php echo esc_attr($name); ?>">Sign Up</a>
         </div>
       <?php }; ?>
       

--- a/single-streamer.php
+++ b/single-streamer.php
@@ -107,7 +107,7 @@
                 <div class="bonus"><?php echo $siteBonus; ?></div>
               </div>
               <div class="site-card__buttons">
-                <a class="button button__primary" href="<?php echo $siteLink; ?>" target="_blank" rel="sponsored noopener">Play</a>
+                <a class="button button__primary" href="<?php echo $siteLink; ?>" target="_blank" rel="sponsored noopener" aria-label="Play at <?php echo esc_attr($siteName); ?>">Play</a>
                 <a class="" href="<?php echo $siteReviewLink; ?>">Read Review</a>
               </div>
             </div>

--- a/template-parts/card/card-hangzhou.php
+++ b/template-parts/card/card-hangzhou.php
@@ -71,7 +71,7 @@
         </a>
       <?php }; ?>
 
-      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener">Get Bonus</a>
+      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo esc_attr($siteName); ?>">Get Bonus</a>
 
     </div>
   </div>


### PR DESCRIPTION
Improves accessibility and SEO by adding dynamic aria-label attributes to buttons with generic text (Play, Visit, Sign Up, Get Bonus), using the casino/site name for context on each button.