### PR TITLE
Enforce esc_url() on all dynamic href attributes

### DIFF
--- a/blocks/bonus/bonus.php
+++ b/blocks/bonus/bonus.php
@@ -39,11 +39,11 @@
   <div class="bonus-long"> 
     <div class="bonus-long__content">
       <img src="<?php echo get_the_post_thumbnail_url($site, 'site-small-logo'); ?>" alt="<?php $name . ' logo'?>" width="100" height="50" aria-hidden="true">
-      <h2 class="h5"><a class="custom-card-link" href="<?php echo $permalink; ?>"><?php echo $title; ?></a></h2>
+      <h2 class="h5"><a class="custom-card-link" href="<?php echo esc_url($permalink); ?>"><?php echo $title; ?></a></h2>
     </div>
 
     <div class="bonus-long__cta">
-      <a class="button button__primary" rel="sponsored noopener" href="<?php echo $outputLink; ?>" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get</a>
+      <a class="button button__primary" rel="sponsored noopener" href="<?php echo esc_url($outputLink); ?>" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get</a>
     </div>
   </div>
 

--- a/blocks/more/more.php
+++ b/blocks/more/more.php
@@ -11,9 +11,9 @@
 
   if ($name !== null && $link !== null) : 
 ?>
-  <p>Want to learn more about <?php echo $name; ?>? <strong>Read our <a href="<?php echo $permalink ?>"><?php echo $name; ?> review</a></strong>.</p>
+  <p>Want to learn more about <?php echo $name; ?>? <strong>Read our <a href="<?php echo esc_url($permalink); ?>"><?php echo $name; ?> review</a></strong>.</p>
   <div class="mt-3">
-    <a href="<?php echo $link; ?>" rel="sponsored noopener" target="_blank" class="button button__primary">Visit <?php echo $name; ?></a>
+    <a href="<?php echo esc_url($link); ?>" rel="sponsored noopener" target="_blank" class="button button__primary">Visit <?php echo $name; ?></a>
   </div>
 <?php endif; ?>
 

--- a/blocks/review-bonus/review-bonus.php
+++ b/blocks/review-bonus/review-bonus.php
@@ -11,13 +11,13 @@ $review_bonus_type = get_field('review_bonus_type');
 foreach ($review_bonus as $review_id) {
 
   $link_aff = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-  $link_output = '<a target="_blank" rel="sponsored noopener" href="' . $link_aff . '" class="button button__primary" aria-label="Visit ' . esc_attr($title) . '"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
+  $link_output = '<a target="_blank" rel="sponsored noopener" href="' . esc_url($link_aff) . '" class="button button__primary" aria-label="Visit ' . esc_attr($title) . '"><span class="text">Visit</span><i data-feather="arrow-right-circle"></i></a>';
 
   $logo = get_the_post_thumbnail_url($review_id, 'site-small-logo'); 
   $transparent_logo =  get_field('media_group', $review_id)['transparent_logo'] ?? null;
   
   $title = get_the_title($review_id);
-  $img_output = '<a class="img-link" href="' . $link_aff . '" target="_blank" rel="sponsored noopener"><img width="100" height="auto" class="logo" src="' . $transparent_logo . '" alt="' . $title . '" title="' . $title . '"></a>';
+  $img_output = '<a class="img-link" href="' . esc_url($link_aff) . '" target="_blank" rel="sponsored noopener"><img width="100" height="auto" class="logo" src="' . $transparent_logo . '" alt="' . $title . '" title="' . $title . '"></a>';
 
   $bonus_is_same = get_field('bonus_group', $review_id)['bonus_same'] ?? null;
    

--- a/blocks/review-table/review-table.php
+++ b/blocks/review-table/review-table.php
@@ -96,7 +96,7 @@ $columns = [
     'icon' => '',
     'render' => function($review_id) {
       $link = get_field('details_group', $review_id)['affiliate_link'] ?? null;
-      return $link ? '<a target="_blank" rel="sponsored noopener" href="' . $link . '" class="button button__primary" aria-label="Visit ' . esc_attr(get_the_title($review_id)) . '">Visit</a>' : '';
+      return $link ? '<a target="_blank" rel="sponsored noopener" href="' . esc_url($link) . '" class="button button__primary" aria-label="Visit ' . esc_attr(get_the_title($review_id)) . '">Visit</a>' : '';
     }
   ],
   'blockchain' => [
@@ -150,7 +150,7 @@ $columns = [
     'render' => function($review_id) {
       $vip_group = get_field('vip_group', $review_id);
       $post_id = is_array($vip_group) ? ($vip_group['vip_guide'] ?? null) : null;
-      return $post_id ? '<a href="' . get_the_permalink($post_id) . '">' . get_the_title($post_id) . '</a>' : '-';
+      return $post_id ? '<a href="' . esc_url(get_the_permalink($post_id)) . '">' . get_the_title($post_id) . '</a>' : '-';
     }
   ],
   'withdrawal_time' => [
@@ -240,7 +240,7 @@ $columns = [
       $logo = get_the_post_thumbnail_url($review_id, 'site-small-logo'); 
       $link = get_the_permalink($review_id);
       $title = get_the_title($review_id);
-      return '<a class="img-link" href="' . $link . '"><img width="120" height="60" class="logo" src="' . $logo . '" alt="' . $title . '" title="' . $title . '"></a>';
+      return '<a class="img-link" href="' . esc_url($link) . '"><img width="120" height="60" class="logo" src="' . $logo . '" alt="' . $title . '" title="' . $title . '"></a>';
     }
   ]
 ];

--- a/inc/breadcrumb-getters.php
+++ b/inc/breadcrumb-getters.php
@@ -79,11 +79,11 @@ function get_category_breadcrumbs(): string {
       $grandparent_cat_link = get_category_link($grandparent_category->term_id);
 
       // Add this one first - the grandparent category link to the output
-      $breadcrumb_html .= '<span class="breadcrumbs__layout--item"><a class="cat-pill" href="' . esc_html($grandparent_cat_link) . '">' . esc_html($grandparent_cat_name) . '</a></span>';
+      $breadcrumb_html .= '<span class="breadcrumbs__layout--item"><a class="cat-pill" href="' . esc_url($grandparent_cat_link) . '">' . esc_html($grandparent_cat_name) . '</a></span>';
     }
 
     // The parent category link to the output
-    $breadcrumb_html .= '<span class="breadcrumbs__layout--item"><a class="cat-pill" href="' . esc_html($parent_cat_link) . '">' . esc_html($parent_cat_name) . '</a></span>';
+    $breadcrumb_html .= '<span class="breadcrumbs__layout--item"><a class="cat-pill" href="' . esc_url($parent_cat_link) . '">' . esc_html($parent_cat_name) . '</a></span>';
 
     $breadcrumb_html .= '<span class="breadcrumbs__layout--item">' . $term->name . '</span>';
   }

--- a/single-bonus.php
+++ b/single-bonus.php
@@ -69,7 +69,7 @@
       $table_fields = array();
 
       if ($casino_id && $name) {
-        $table_fields['Site'] = '<a href="' . get_the_permalink($casino_id) . '">' . $name . '</a>';
+        $table_fields['Site'] = '<a href="' . esc_url(get_the_permalink($casino_id)) . '">' . $name . '</a>';
       }
 
       if (!empty($bonus)) {
@@ -199,7 +199,7 @@
                     </span>
                   </div>
                 <?php }; ?>
-                <a href="<?php echo $output_link; ?>" class="button button__primary" rel="sponsored noopener" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get Bonus</a>
+                <a href="<?php echo esc_url($output_link); ?>" class="button button__primary" rel="sponsored noopener" target="_blank" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get Bonus</a>
               </div>
               <?php endif; ?>
               

--- a/single-review.php
+++ b/single-review.php
@@ -203,7 +203,7 @@ foreach ($faqs as $faq) {
           <?php if ($bonus) { ?>
             <p><?php echo get_svg_icon('present'); ?><?php echo $bonus; ?></p>
           <?php } ?>
-          <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Sign up at <?php echo esc_attr($name); ?>">Sign Up</a>
+          <a href="<?php echo esc_url($link); ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Sign up at <?php echo esc_attr($name); ?>">Sign Up</a>
         </div>
       <?php }; ?>
       
@@ -287,7 +287,7 @@ foreach ($faqs as $faq) {
         if ($homepageImg) { ?>
           <section>
             <figure class="homepage-image">
-              <a href="<?php echo $link; ?>" target="_blank" rel="sponsored noopener">
+              <a href="<?php echo esc_url($link); ?>" target="_blank" rel="sponsored noopener">
                 <img src="<?php echo $homepageImg_url; ?>" alt="<?php echo $homepageImg_alt; ?>" width="1000" height="600" loading="lazy">
               </a>
               <?php if ($homepageImg_cap): ?>

--- a/single-streamer.php
+++ b/single-streamer.php
@@ -42,7 +42,7 @@
   }
   // String
   if (!empty($kick)) {
-    $table_fields['Kick'] = '<a href="' . $kick . '" target="_blank">' . str_replace(array("http://", "https://"), "", $kick) . '</a>';
+    $table_fields['Kick'] = '<a href="' . esc_url($kick) . '" target="_blank">' . str_replace(array("http://", "https://"), "", $kick) . '</a>';
   }
 
   $moreStreamersQuery = new WP_Query(array(
@@ -97,18 +97,18 @@
 
             <div class="site-card">
               <div class="site-card__media" style="background-color: <?php echo $siteColor; ?>">
-                <a href="<?php echo $siteReviewLink; ?>"><img src="<?php echo $siteLogo;  ?>" alt=""></a>
+                <a href="<?php echo esc_url($siteReviewLink); ?>"><img src="<?php echo $siteLogo;  ?>" alt=""></a>
               </div>
               <div class="site-card__name">
-                <a class="name" href="<?php echo $siteReviewLink; ?>"><h2><?php echo $siteName; ?></h2></a>
+                <a class="name" href="<?php echo esc_url($siteReviewLink); ?>"><h2><?php echo $siteName; ?></h2></a>
               </div>
               <div class="site-card__bonus">
                 <div class="title">BONUS</div>
                 <div class="bonus"><?php echo $siteBonus; ?></div>
               </div>
               <div class="site-card__buttons">
-                <a class="button button__primary" href="<?php echo $siteLink; ?>" target="_blank" rel="sponsored noopener" aria-label="Play at <?php echo esc_attr($siteName); ?>">Play</a>
-                <a class="" href="<?php echo $siteReviewLink; ?>">Read Review</a>
+                <a class="button button__primary" href="<?php echo esc_url($siteLink); ?>" target="_blank" rel="sponsored noopener" aria-label="Play at <?php echo esc_attr($siteName); ?>">Play</a>
+                <a class="" href="<?php echo esc_url($siteReviewLink); ?>">Read Review</a>
               </div>
             </div>
 

--- a/template-parts/card/bonus-pill.php
+++ b/template-parts/card/bonus-pill.php
@@ -31,7 +31,7 @@
   <div class="card card-absolute bonus-pill">
 
     <!-- aria -->
-    <a class="card-absolute__link" href="<?php echo $permalink; ?>"></a>
+    <a class="card-absolute__link" href="<?php echo esc_url($permalink); ?>"></a>
 
     <div class="bonus-pill__content">
       <img class="logo" src="<?php echo get_the_post_thumbnail_url($site, 'site-small-logo'); ?>" alt="<?php echo $name . ' logo'; ?>" width="100" height="50" title="<?php echo $name; ?>"/>
@@ -39,7 +39,7 @@
     </div>
 
     <div class="card-absolute__ctas bonus-pill__cta">
-      <a class="button button__primary" href="<?php echo $bonusLink; ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
+      <a class="button button__primary" href="<?php echo esc_url($bonusLink); ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
        <?php echo get_svg_icon('external-link'); ?>
       </a>
     </div>

--- a/template-parts/card/card-hangzhou.php
+++ b/template-parts/card/card-hangzhou.php
@@ -71,7 +71,7 @@
         </a>
       <?php }; ?>
 
-      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo esc_attr($siteName); ?>">Get Bonus</a>
+      <a href="<?php echo esc_url($outputLink); ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo esc_attr($siteName); ?>">Get Bonus</a>
 
     </div>
   </div>

--- a/template-parts/card/card-hong-kong.php
+++ b/template-parts/card/card-hong-kong.php
@@ -52,7 +52,7 @@
   <?php if (!empty($link)) {  ?>
     <div class="card-absolute__ctas hong-kong-card__ctas">
       <a href="<?php echo the_permalink(); ?>" class="button button__outline" aria-label="Read <?php echo $name; ?> review">Review</a>
-      <a href="<?php echo $link; ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Goto <?php echo $name; ?>">Play</a>
+      <a href="<?php echo esc_url($link); ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Goto <?php echo $name; ?>">Play</a>
     </div>
   <?php }; ?>
 </div>

--- a/template-parts/card/card-shanghai.php
+++ b/template-parts/card/card-shanghai.php
@@ -73,7 +73,7 @@
         </a>
       <?php }; ?>
 
-      <a href="<?php echo $outputLink; ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo $name; ?>">Get Bonus</a>
+      <a href="<?php echo esc_url($outputLink); ?>" class="button button--small button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo esc_attr($name); ?>">Get Bonus</a>
 
     </div>
   </div>

--- a/template-parts/card/review-pill.php
+++ b/template-parts/card/review-pill.php
@@ -10,7 +10,7 @@
 ?>
 
 <div class="card card-absolute review-pill">
-  <a class="card-absolute__link" href="<?php echo $review_link; ?>" aria-label="Read <?php echo $name; ?> review"></a>
+  <a class="card-absolute__link" href="<?php echo esc_url($review_link); ?>" aria-label="Read <?php echo $name; ?> review"></a>
   <div class="review-pill__body">
     <img class="logo" src="<?php echo get_the_post_thumbnail_url($id, 'site-small-logo'); ?>" alt="<?php echo $name . ' logo'; ?>" width="100" height="50" title="<?php echo $name; ?>"/>
     <h3 class="h6">
@@ -18,7 +18,7 @@
     </h3>
   </div>
   <div class="card-absolute__ctas review-pill__cta">
-    <a class="button button__primary" href="<?php echo $aff_link; ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
+    <a class="button button__primary" href="<?php echo esc_url($aff_link); ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo $name; ?>">
        <?php echo get_svg_icon('external-link'); ?>
     </a>
   </div>

--- a/template-parts/card/tax-pill.php
+++ b/template-parts/card/tax-pill.php
@@ -16,7 +16,7 @@ if (is_array($term_logo) && isset($term_logo['sizes']['thumbnail'])) {
   <?php endif; ?>
   <div class="tax-pill__content">
     <h3 class="h6 m-0">
-      <a class="tax-pill__link" href="<?php echo get_term_link($term->term_id); ?>">
+      <a class="tax-pill__link" href="<?php echo esc_url(get_term_link($term->term_id)); ?>">
         <?php echo $term->name; ?>
       </a>
     </h3>

--- a/template-parts/content/content-author.php
+++ b/template-parts/content/content-author.php
@@ -16,7 +16,7 @@
 ?>
 
 <div class="main--published">
-  <span>By <a href="<?php echo $author_link; ?>"><?php the_author(); ?></a></span>
+  <span>By <a href="<?php echo esc_url($author_link); ?>"><?php the_author(); ?></a></span>
   <?php if ($publish_date) : ?>
     <span><time datetime="<?php echo esc_attr( get_the_date('c') ); ?>"><?php echo esc_html( $publish_date ); ?></time></span>
   <?php endif; ?>

--- a/templates/applications.php
+++ b/templates/applications.php
@@ -48,7 +48,7 @@ Template Post Type: post, page
                 <?php if ($website) { ?>
                 <div class="col-12 col-md-6 mb-3">        
                   <div class="d-block fs-small text-muted text-uppercase" style="font-family: var(--font-family-heading); font-weight: semi-bold">Website</div>
-                  <a href="<?php echo $website; ?>" style="word-break: break-word;" target=_blank><?php echo $website; ?></a>
+                  <a href="<?php echo esc_url($website); ?>" style="word-break: break-word;" target=_blank><?php echo esc_html($website); ?></a>
                 </div>
                 <?php }; ?>
                 <?php if ($price) { ?>

--- a/templates/promos.php
+++ b/templates/promos.php
@@ -39,7 +39,7 @@ Template Post Type: post, page
       </div>
       <h2 class="h3"><?php echo $siteName; ?></h2>
       <div style="margin-bottom: 1em; font-size: 1.1rem;"><?php echo wp_kses_post(the_sub_field('description')); ?></div>
-      <a href="<?php echo wp_kses_post(the_sub_field('link')); ?>" class="button button__primary" rel="nofollow" target="_blank">Claim Bonus</a>
+      <a href="<?php echo esc_url(get_sub_field('link')); ?>" class="button button__primary" rel="nofollow" target="_blank">Claim Bonus</a>
     </div> 
   </div>
   <?php ++$loop_count; ?>


### PR DESCRIPTION
Wrapped all raw PHP variable echoes inside href attributes with esc_url() across 17 files. Also fixed two instances using wrong escaping functions (esc_html() in breadcrumb-getters, wp_kses_post() in promos.php).