### PR TITLE
feat(card-kunming): Affiliate logo links and hr styling for taxonomy content

### DIFF
--- a/assets/css/modules/_typography.scss
+++ b/assets/css/modules/_typography.scss
@@ -129,6 +129,12 @@ h6 {
     font-size: clamp(1.09rem, 0.95rem + 0.45vw, 1.2rem);
   }
 
+  hr {
+    margin: var(--size-700) 0;
+    border: none;
+    border-top: 2px solid var(--color-muted-200);
+  }
+
   a {
     &:not(.btn):not(.button):not(.tax-pill__link):not(.custom-card-link):not(.img-link) {
       text-decoration: none;

--- a/template-parts/card/card-kunming.php
+++ b/template-parts/card/card-kunming.php
@@ -25,15 +25,20 @@
   <div class="card-kunming__main">
 
     <div class="card-kunming__media">
-      <div class="km-card-bg-color" style="background-color: <?php echo esc_attr($siteColor); ?>">
-        <img
-          src="<?php echo esc_url(get_the_post_thumbnail_url(get_the_ID(), 'site-small-logo')); ?>"
-          width="90" height="52"
-          alt="<?php echo esc_attr($name . ' logo'); ?>"
-          aria-hidden="true"
-          <?php echo $exclude_lazyload ? 'class="exclude-lazyload"' : ''; ?>
-        >
-      </div>
+      <?php if ($link) : ?>
+      <a href="<?php echo esc_url($link); ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo esc_attr($name); ?>">
+      <?php endif; ?>
+        <div class="km-card-bg-color" style="background-color: <?php echo esc_attr($siteColor); ?>">
+          <img
+            src="<?php echo esc_url(get_the_post_thumbnail_url(get_the_ID(), 'site-small-logo')); ?>"
+            width="90" height="52"
+            alt="<?php echo esc_attr($name . ' logo'); ?>"
+            <?php echo $exclude_lazyload ? 'class="exclude-lazyload"' : ''; ?>
+          >
+        </div>
+      <?php if ($link) : ?>
+      </a>
+      <?php endif; ?>
     </div>
 
     <div class="card-kunming__bonus">


### PR DESCRIPTION
## Changes
- card-kunming logo badge is now a fully clickable affiliate link
  (rel="sponsored noopener", wraps the entire coloured background)
- Plain <hr> elements inside .main--content now match the
  wp-block-separator style — grey, 2px, equal spacing above and below
## Files
- template-parts/card/card-kunming.php
- assets/css/modules/_typography.scss
