### PR TITLE
feat(card-suzhou): redesign card layout with structured columns

### DIFF
--- a/assets/css/modules/_buttons.scss
+++ b/assets/css/modules/_buttons.scss
@@ -56,12 +56,12 @@ button.round-icon {
   }
 
   &__primary {
-    background-color: var(--color-primary-500);
+    background: linear-gradient(to right, var(--color-primary-500), var(--color-primary-600));
     color: #ffffff;
 
     &:hover,
     &:focus {
-      background-color: var(--color-primary-700);
+      background: linear-gradient(to right, var(--color-primary-600), var(--color-primary-700));
       color: #ffffff;
     }
   }

--- a/assets/css/modules/_cards.scss
+++ b/assets/css/modules/_cards.scss
@@ -1289,3 +1289,251 @@ section.articles-box {
     }
   }
 }
+
+/**
+ * Card Suzhou — full-width bonus card for bonus type taxonomy pages
+ */
+.card-suzhou {
+  margin-top: var(--size-300);
+  max-width: 1120px;
+  border: 1px solid var(--color-muted-200);
+  border-radius: var(--border-radius);
+  background-color: #ffffff;
+  overflow: hidden;
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: var(--size-600);
+    padding: var(--size-400);
+
+    @include breakpoint(medium) {
+      flex-direction: row;
+      align-items: center;
+      text-align: left;
+      gap: var(--size-500);
+    }
+  }
+
+  &__media {
+    flex-shrink: 0;
+
+    .sz-card-bg-color {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 110px;
+      height: 70px;
+      border-radius: var(--border-radius);
+      overflow: hidden;
+
+      img {
+        width: 90px;
+        height: auto;
+        border: none;
+      }
+    }
+  }
+
+  &__site {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-100);
+
+    @include breakpoint(medium) {
+      width: 180px;
+    }
+
+    h3 {
+      font-size: 15px;
+      font-weight: 700;
+      margin: 0 0 var(--size-100);
+    }
+  }
+
+  &__bonus-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--size-100);
+  }
+
+  &__bonus-title {
+    font-size: 14px;
+    color: var(--color-muted-500);
+  }
+
+  &__bonus-amount {
+    font-size: 22px;
+    font-weight: 700;
+  }
+
+  &__bonus-plus {
+    font-size: 14px;
+    color: var(--color-muted-500);
+  }
+
+  &__exclusive-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background-color: var(--color-primary-50);
+    border: 1px solid var(--color-primary-200);
+    color: var(--color-primary-700);
+    border-radius: 100px;
+    padding: 3px 10px 3px 6px;
+    font-size: 12px;
+    font-weight: 600;
+
+    svg {
+      width: 13px;
+      height: 13px;
+      stroke: var(--color-primary-700);
+    }
+  }
+
+  &__code {
+    display: flex;
+    align-items: center;
+
+    @include breakpoint(medium) {
+      flex-shrink: 0;
+      justify-content: center;
+    }
+
+    .bonus-code {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: none;
+      border: 1px dashed var(--color-muted-300);
+      border-radius: 8px;
+      padding: 8px 10px 6px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--color-muted-500);
+      cursor: pointer;
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+      margin-top: 8px;
+
+      &:hover {
+        border-color: var(--color-primary-400);
+        color: var(--color-primary-600);
+
+        .bonus-code__label {
+          color: var(--color-primary-500);
+        }
+      }
+
+      svg {
+        flex-shrink: 0;
+        opacity: 0.7;
+      }
+    }
+
+    .bonus-code__label {
+      position: absolute;
+      top: -8px;
+      left: 8px;
+      background-color: #ffffff;
+      padding: 0 4px;
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--color-muted-400);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      line-height: 1;
+    }
+  }
+
+  &__ctas {
+    display: flex;
+    gap: var(--size-200);
+    align-items: center;
+    flex-wrap: wrap;
+
+    @include breakpoint(medium) {
+      flex-direction: column;
+      flex-shrink: 0;
+      width: 160px;
+      flex-wrap: nowrap;
+
+      .button {
+        width: 100%;
+        text-align: center;
+      }
+    }
+  }
+
+  &__info-boxes {
+    border-top: 1px solid var(--color-muted-100);
+    background-color: var(--color-bg-50);
+  }
+
+  &__details-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--size-200);
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: var(--size-200) var(--size-400);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-muted-400);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+
+    span.toggle-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background-color: var(--color-primary-50);
+      color: var(--color-primary-700);
+      flex-shrink: 0;
+
+      &:hover {
+        background-color: var(--color-primary-100);
+      }
+
+      svg {
+        width: 11px;
+        height: 11px;
+        transition: transform 0.2s ease;
+      }
+    }
+  }
+
+  &__details-content {
+    height: 0;
+    overflow: hidden;
+
+    &.expanded {
+      height: auto;
+      padding: 0 var(--size-400) var(--size-200);
+    }
+  }
+
+  .review-info-boxes--small {
+    gap: var(--size-100);
+
+    li {
+      padding: var(--size-100) var(--size-200);
+    }
+
+    .review-info-boxes__value {
+      font-size: 13px;
+    }
+  }
+}

--- a/assets/css/modules/_layouts.scss
+++ b/assets/css/modules/_layouts.scss
@@ -129,22 +129,6 @@
 	}
 }
 
-.perthshire-section {
-	display: grid;
-	gap: var(--size-500);
-	grid-template-columns: 1fr;
-	margin-top: var(--size-600);
-
-	@include breakpoint(medium) {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
-	@include breakpoint(large) {
-		grid-template-columns: repeat(4, 1fr);
-	}
-}
-
-
 .aberdeenshire-section {
 	display: grid;
 	gap: var(--size-500);

--- a/inc/load-more-endpoint.php
+++ b/inc/load-more-endpoint.php
@@ -10,6 +10,74 @@ function km_load_more_endpoint() {
 
 add_action('rest_api_init', 'km_load_more_endpoint');
 
+function km_load_more_bonuses_endpoint() {
+  register_rest_route('chaser/v2', 'bonuses', array(
+    'methods'             => 'GET',
+    'callback'            => 'km_load_more_bonuses_callback',
+    'permission_callback' => '__return_true',
+  ));
+}
+add_action('rest_api_init', 'km_load_more_bonuses_endpoint');
+
+function km_load_more_bonuses_callback($data) {
+  $taxonomy  = sanitize_key($data['taxonomy']);
+  $term_slug = sanitize_text_field($data['term']);
+  $page      = !empty($data['page']) ? absint($data['page']) : 1;
+  $per_page  = !empty($data['per_page']) ? absint($data['per_page']) : 6;
+
+  if (!$taxonomy || !$term_slug) {
+    return new WP_Error('missing_params', 'taxonomy and term are required', array('status' => 400));
+  }
+
+  $term     = get_term_by('slug', $term_slug, $taxonomy);
+  $featured = get_field('featured_bonuses', $term) ?? [];
+  $featured = array_map('intval', $featured);
+
+  $additional = get_posts(array(
+    'post_type'      => 'bonus',
+    'posts_per_page' => -1,
+    'fields'         => 'ids',
+    'tax_query'      => array(array(
+      'taxonomy' => $taxonomy,
+      'field'    => 'slug',
+      'terms'    => $term_slug,
+    )),
+    'meta_query'   => bonus_expired_meta_query(),
+    'post__not_in' => $featured,
+  ));
+
+  $merged = array_merge($featured, $additional);
+
+  if (empty($merged)) {
+    return array('html' => '', 'currentPage' => 1, 'totalPages' => 0);
+  }
+
+  $query = new WP_Query(array(
+    'post_type'      => 'bonus',
+    'posts_per_page' => $per_page,
+    'paged'          => $page,
+    'post__in'       => $merged,
+    'orderby'        => 'post__in',
+    'meta_query'     => bonus_expired_meta_query(),
+  ));
+
+  ob_start();
+  if ($query->have_posts()) {
+    while ($query->have_posts()) {
+      $query->the_post();
+      get_template_part('template-parts/card/card', 'suzhou');
+    }
+    wp_reset_postdata();
+  }
+  $html = ob_get_clean();
+
+  return array(
+    'html'        => $html,
+    'currentPage' => $page,
+    'totalPages'  => (int) $query->max_num_pages,
+  );
+}
+
 function km_load_more_callback($data) {
   $taxonomy  = sanitize_key($data['taxonomy']);
   $term_slug = sanitize_text_field($data['term']);

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function () {
     singleReview();
   }
 
-  if (document.querySelector('.card-kunming')) {
+  if (document.querySelector('.card-kunming, .card-suzhou')) {
     kunmingCard();
   }
 

--- a/src/modules/KunmingCard.js
+++ b/src/modules/KunmingCard.js
@@ -1,12 +1,12 @@
 export function kunmingCard() {
-  if (!document.querySelector('.card-kunming')) return;
+  if (!document.querySelector('.card-kunming, .card-suzhou')) return;
 
   document.addEventListener('click', (e) => {
-    const toggle = e.target.closest('.card-kunming__details-toggle');
+    const toggle = e.target.closest('.card-kunming__details-toggle, .card-suzhou__details-toggle');
     if (!toggle) return;
 
-    const content = toggle.closest('.card-kunming__info-boxes')
-      ?.querySelector('.card-kunming__details-content');
+    const infoBoxes = toggle.closest('.card-kunming__info-boxes, .card-suzhou__info-boxes');
+    const content = infoBoxes?.querySelector('.card-kunming__details-content, .card-suzhou__details-content');
     if (!content) return;
 
     const expanded = toggle.getAttribute('aria-expanded') === 'true';

--- a/src/modules/TaxonomyLoadMore.js
+++ b/src/modules/TaxonomyLoadMore.js
@@ -11,6 +11,7 @@ class TaxonomyLoadMore {
     this.taxonomy   = this.cardList.dataset.taxonomy;
     this.term       = this.cardList.dataset.term;
     this.totalPages = parseInt(this.cardList.dataset.totalPages, 10);
+    this.endpoint   = this.cardList.dataset.endpoint || 'chaser/v2/reviews';
     this.origin     = window.location.origin;
 
     this.button.addEventListener('click', () => this.handleClick());
@@ -29,7 +30,7 @@ class TaxonomyLoadMore {
         page,
       });
 
-      const response = await fetch(`${this.origin}/wp-json/chaser/v2/reviews?${params.toString()}`);
+      const response = await fetch(`${this.origin}/wp-json/${this.endpoint}?${params.toString()}`);
       const data = await response.json();
       const { html, currentPage, totalPages } = data;
 

--- a/style.css
+++ b/style.css
@@ -4,5 +4,5 @@ Theme URI: https://bitcoinchaser.com
 Description: A Theme for WordPress with Bootstrap for styling.
 Author: Ross Findlay  
 Author URI: https://bitocinchaser.com
-Version: 10.999
+Version: 11.001
 */

--- a/taxonomy-bonus_type.php
+++ b/taxonomy-bonus_type.php
@@ -38,12 +38,13 @@ if (empty($merged_bonuses)) {
   $query = null; 
 } else {
   $query = new WP_Query(array(
-    'post_type'  => 'bonus',
-    'paged'      => $paged,
-    'post__in'   => $merged_bonuses,
-    'orderby'    => 'post__in',
-    'meta_query' => bonus_expired_meta_query()
-  )); 
+    'post_type'      => 'bonus',
+    'posts_per_page' => 6,
+    'paged'          => $paged,
+    'post__in'       => $merged_bonuses,
+    'orderby'        => 'post__in',
+    'meta_query'     => bonus_expired_meta_query()
+  ));
 };
 
 $title_output = '';
@@ -78,26 +79,35 @@ switch($term_name) {
     </section>
 
     <!-- MAIN QUERY -->
-    <section class="perthshire-section">
-      <?php 
-        if ($query && $query->have_posts()) : 
-          while ($query->have_posts()) : $query->the_post();     
-            get_template_part('template-parts/card/card', 'shanghai');
-          endwhile; 
-          wp_reset_postdata();
-        else : ?>
+    <section>
+      <div id="km-card-list"
+        class="mt-4 flex flex-col gap-3"
+        data-term="<?php echo esc_attr($term_slug); ?>"
+        data-taxonomy="<?php echo esc_attr($taxonomy); ?>"
+        data-total-pages="<?php echo esc_attr($query ? $query->max_num_pages : 0); ?>"
+        data-endpoint="chaser/v2/bonuses"
+      >
+        <?php if ($query && $query->have_posts()) : ?>
+          <?php while ($query->have_posts()) : $query->the_post(); ?>
+            <?php get_template_part('template-parts/card/card', 'suzhou'); ?>
+          <?php endwhile; wp_reset_postdata(); ?>
+        <?php else : ?>
           <div class="p-2 bg-white border-radius mt-4 border-top" style="font-size: 18px;">
-            <p>There are currently <strong>no <?php echo $term_name; ?> bonuses available</strong>.</p> 
+            <p>There are currently <strong>no <?php echo esc_html($term_name); ?> bonuses available</strong>.</p>
             <p>Please explore the <a href="/bonuses/">other bonuses</a> we have currently listed.</p>
           </div>
         <?php endif; ?>
-      </section><!-- .perthshire-section --> 
+      </div>
 
-      <?php if (!empty($merged_bonuses)) {
-        get_template_part('template-parts/content/content', 'pagination', array('query' => $query));
-      }; ?>
-
-
+      <?php if ($query && $query->max_num_pages > 1) : ?>
+        <div class="km-load-more-wrapper mt-3">
+          <button class="km-load-more button button__outline" data-page="2">
+            <i data-feather="chevron-down"></i>
+            <span>Load More</span>
+          </button>
+        </div>
+      <?php endif; ?>
+    </section>
 
     <!-- MAIN CONTENT -->
     <?php if ($paged == 1) : ?>

--- a/template-parts/bonus/bonus-info-boxes.php
+++ b/template-parts/bonus/bonus-info-boxes.php
@@ -1,0 +1,35 @@
+<?php
+$bonus_id = $args['bonus_id'] ?? get_the_ID();
+
+$expiry_date       = get_field('expiry_date', $bonus_id);
+$turnover          = get_field('turnover', $bonus_id);
+$min_deposit       = get_field('min_deposit', $bonus_id);
+$max_bonus         = get_field('max_bonus', $bonus_id);
+$max_cashout       = get_field('max_cashout', $bonus_id);
+$players_eligible  = get_field('players_eligible', $bonus_id);
+$game              = get_field('game', $bonus_id);
+
+$boxes = [];
+
+if ($expiry_date)      $boxes[] = ['label' => 'Expires',              'icon' => 'calendar',    'value' => esc_html(date('d M Y', strtotime($expiry_date)))];
+if ($turnover)         $boxes[] = ['label' => 'Wagering Requirement',  'icon' => 'percent',     'value' => esc_html($turnover)];
+if ($min_deposit)      $boxes[] = ['label' => 'Min. Deposit',          'icon' => 'credit-card', 'value' => esc_html($min_deposit)];
+if ($max_bonus)        $boxes[] = ['label' => 'Max. Bonus',            'icon' => 'arrow-up',    'value' => esc_html($max_bonus)];
+if ($max_cashout)      $boxes[] = ['label' => 'Max. Cashout',          'icon' => 'arrow-up',    'value' => esc_html($max_cashout)];
+if ($players_eligible) $boxes[] = ['label' => 'Players Eligible',      'icon' => 'users',       'value' => esc_html($players_eligible)];
+if ($game)             $boxes[] = ['label' => 'Game Eligible',         'icon' => 'grid',        'value' => esc_html(is_array($game) ? implode(', ', wp_list_pluck($game, 'name')) : $game)];
+
+if (empty($boxes)) return;
+?>
+
+<ul class="review-info-boxes review-info-boxes--small">
+  <?php foreach ($boxes as $box) : ?>
+    <li>
+      <span class="review-info-boxes__label">
+        <span class="review-info-boxes__label-icon"><i data-feather="<?php echo esc_attr($box['icon']); ?>"></i></span>
+        <?php echo $box['label']; ?>
+      </span>
+      <span class="review-info-boxes__value"><?php echo $box['value']; ?></span>
+    </li>
+  <?php endforeach; ?>
+</ul>

--- a/template-parts/card/card-suzhou.php
+++ b/template-parts/card/card-suzhou.php
@@ -1,0 +1,106 @@
+<?php
+  $bonus_id = $args['id'] ?? get_the_ID();
+  if (!$bonus_id) return;
+
+  $title     = get_field('bonus_title', $bonus_id);
+  $bonus     = get_field('bonus', $bonus_id);
+  $plus      = get_field('bonus_plus', $bonus_id);
+  $code      = get_field('code', $bonus_id);
+  $bonusLink = get_field('bonus_link', $bonus_id);
+
+  $site = get_field('single_bonus_casino', $bonus_id)[0] ?? null;
+  if (!$site) return;
+
+  $detailsGroup = get_field('details_group', $site);
+  $siteName     = $detailsGroup['name'];
+  $siteLink     = $detailsGroup['affiliate_link'];
+  $outputLink   = $bonusLink ?: $siteLink;
+
+  $mediaGroup = get_field('media_group', $site);
+  $siteColor  = $mediaGroup['theme_color'] ?? '#ffffff';
+
+  $exclusive = get_field('exclusive', $bonus_id);
+?>
+
+<div class="card card-suzhou">
+
+  <div class="card-suzhou__main">
+
+  <div class="card-suzhou__media">
+    <?php if ($outputLink) : ?>
+    <a href="<?php echo esc_url($outputLink); ?>" target="_blank" rel="sponsored noopener" aria-label="Visit <?php echo esc_attr($siteName); ?>">
+    <?php endif; ?>
+      <div class="sz-card-bg-color" style="background-color: <?php echo esc_attr($siteColor); ?>">
+        <img
+          src="<?php echo esc_url(get_the_post_thumbnail_url($site, 'site-small-logo')); ?>"
+          width="90" height="52"
+          alt="<?php echo esc_attr($siteName . ' logo'); ?>"
+        >
+      </div>
+    <?php if ($outputLink) : ?>
+    </a>
+    <?php endif; ?>
+  </div>
+
+  <div class="card-suzhou__site">
+    <h3><?php echo esc_html($siteName); ?></h3>
+    <?php if ($exclusive) : ?>
+      <span class="card-suzhou__exclusive-pill">
+        <i data-feather="star"></i>
+        Exclusive
+      </span>
+    <?php endif; ?>
+  </div>
+
+  <div class="card-suzhou__bonus-info">
+    <?php if ($title) : ?>
+      <div class="card-suzhou__bonus-title"><?php echo esc_html($title); ?></div>
+    <?php endif; ?>
+    <?php if ($bonus) : ?>
+      <div class="card-suzhou__bonus-amount"><?php echo esc_html($bonus); ?></div>
+    <?php endif; ?>
+    <?php if ($plus) : ?>
+      <div class="card-suzhou__bonus-plus"><?php echo esc_html($plus); ?></div>
+    <?php endif; ?>
+  </div>
+
+  <?php if ($code) : ?>
+  <div class="card-suzhou__code">
+    <button class="bonus-code" type="button" aria-label="Copy bonus code to clipboard">
+      <span class="bonus-code__label">Code</span>
+      <span class="bonus-code__code"><?php echo esc_html($code); ?></span>
+      <span class="bonus-code__icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-copy" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"/>
+        </svg>
+      </span>
+    </button>
+  </div>
+  <?php endif; ?>
+
+  <div class="card-suzhou__ctas">
+    <a href="<?php echo esc_url(get_permalink($bonus_id)); ?>" class="button button__outline" aria-label="View <?php echo esc_attr($siteName); ?> bonus">View Bonus</a>
+    <?php if ($outputLink) : ?>
+      <a href="<?php echo esc_url($outputLink); ?>" class="button button__primary" target="_blank" rel="sponsored noopener" aria-label="Claim bonus at <?php echo esc_attr($siteName); ?>">Get Bonus</a>
+    <?php endif; ?>
+  </div>
+
+  </div><!-- .card-suzhou__main -->
+
+  <?php
+  ob_start();
+  get_template_part('template-parts/bonus/bonus-info-boxes', null, ['bonus_id' => $bonus_id]);
+  $info_boxes_html = ob_get_clean();
+  if (!empty(trim($info_boxes_html))) : ?>
+  <div class="card-suzhou__info-boxes">
+    <button class="card-suzhou__details-toggle" aria-expanded="false" aria-label="Toggle bonus details">
+      Details
+      <span class="toggle-icon"><?php echo get_svg_icon('chevron-down'); ?></span>
+    </button>
+    <div class="card-suzhou__details-content">
+      <?php echo $info_boxes_html; ?>
+    </div>
+  </div>
+  <?php endif; ?>
+
+</div>


### PR DESCRIPTION
Added the card-suzhou component with a clear 5-column desktop layout:
logo | site name | bonus info | code | CTAs
Changes:

- Fix __site to 180px width so columns align consistently across cards
- Extract bonus code into its own __code column with MUI-style notched label
- Centre-align all content on mobile
- Add subtle horizontal gradient to primary button (primary-500 → primary-600)